### PR TITLE
Include the appropriate MIME type in response header

### DIFF
--- a/src/com/frosthex/timingsystem/restapi/network/SparkManager.java
+++ b/src/com/frosthex/timingsystem/restapi/network/SparkManager.java
@@ -53,6 +53,8 @@ public class SparkManager {
 		staticFiles.externalLocation(pathToPublicHtmlFolder);
 		
 		before("/api/*/readonly/*", (request, response) -> {
+			response.type("application/json");
+			
 			// Allow all origins
 			response.header("Access-Control-Allow-Origin", "*");
 			


### PR DESCRIPTION
This would allow browsers to format the data properly.